### PR TITLE
Added vscode setup. Removed linkPath function.

### DIFF
--- a/vscode/keybindings.json
+++ b/vscode/keybindings.json
@@ -1,0 +1,3 @@
+[
+  { "key": "ctrl+alt+shift+s", "command": "workbench.action.files.saveAll" }
+]

--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "editor.formatOnSave": true,
+    "editor.tabSize": 2,
+    "eslint.enable": true,
+    "prettier.requireConfig": true,
+    "workbench.iconTheme": "vscode-icons",
+    "workbench.colorTheme": "One Dark Pro",
+    "window.zoomLevel": 1
+}

--- a/vscode/snippets/javascript.json
+++ b/vscode/snippets/javascript.json
@@ -1,0 +1,10 @@
+{
+	"Console Log": {
+		"prefix": "clog",
+		"body": [
+			"console.log('$1');",
+			"$2"
+		],
+		"description": "Log output to console"
+	}
+}


### PR DESCRIPTION
`vscode/snippets/javascript.json` serves as a placeholder snippet.

Quotation marks around path variables prevent paths with spaces from splitting into multiple arguments when being passed into a function.