### PR TITLE
Added libomp to Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -5,6 +5,7 @@ brew 'awscli'
 brew 'flow'
 brew 'git'
 brew 'jq'
+brew 'libomp'
 # Override default Vim installation.
 # By default, OSX has an older version of Vim installed.
 brew 'macvim', args: [ '--override-system-vim' ]


### PR DESCRIPTION
Importing the `lightgbm` gradient boosting framework within a Python script throws the following error:

`Reason: image not found`

To resolve this issue, build LightGBM in Mac. In a later version of LightGBM (v2.2.1), the library file is built by the Apple Clang compiler instead of the gcc compiler. Hence, install the OpenMP library to run LightGBM on the system with the Apple Clang compiler.