### PR TITLE
Jupyter Configuration - Word-Wrap Markdown/Code Cells

### DIFF
--- a/.jupyter/nbconfig/notebook.json
+++ b/.jupyter/nbconfig/notebook.json
@@ -1,0 +1,12 @@
+{
+  "MarkdownCell": {
+    "cm_config": {
+      "lineWrapping": true
+    }
+  },
+  "CodeCell": {
+    "cm_config": {
+      "lineWrapping": true
+    }
+  }
+}


### PR DESCRIPTION
Added Jupyter notebook configuration to word-wrap markdown/code cells.

To determine the location of the Jupyter configuration directory, type the following command:

```bash
$ jupyter --config-dir
```

Then, edit/create a `nbconfig/notebook.json` file and add the necessary configuration. Restart Jupyter and reload the notebook for the changes to become active.

