### PR TITLE
VSCode - Editor Settings

### DIFF
--- a/vscode/settings.json
+++ b/vscode/settings.json
@@ -1,4 +1,5 @@
 {
+    "breadcrumbs.enabled": true,
     "editor.detectIndentation": true,
     "editor.formatOnSave": true,
     "editor.insertSpaces": true,
@@ -12,7 +13,9 @@
     "prettier.requireConfig": true,
     "telemetry.enableCrashReporter": false,
     "telemetry.enableTelemetry": false,
-    "workbench.iconTheme": "vscode-icons",
+    "window.title": "${dirty} ${activeEditorMedium}${separator}${rootName}",
+    "window.zoomLevel": 1,
     "workbench.colorTheme": "One Dark Pro",
-    "window.zoomLevel": 1
+    "workbench.editor.enablePreviewFromQuickOpen": false,
+    "workbench.iconTheme": "vscode-icons"
 }


### PR DESCRIPTION
* Enabled breadcrumbs.
* Disabled preview editors when opened from quick open.
* Customized the title bar to include the full path of the currently opened file and an icon to indicate if the active editor is dirty.
![](https://www.dl.dropboxusercontent.com/s/wcrpqk2rrfbzk89/Screenshot%202020-01-15%2016.07.00.png)