### PR TITLE
Removed postgresql and pgadmin from Brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -10,7 +10,6 @@ brew 'libomp'
 # Override default Vim installation.
 # By default, OSX has an older version of Vim installed.
 brew 'macvim', args: [ '--override-system-vim' ]
-brew 'postgresql'
 brew 'prisma'
 brew 'python@2'
 brew 'python3'
@@ -41,7 +40,6 @@ cask 'inkscape'
 cask 'iterm2'
 cask 'java'
 cask 'mysqlworkbench'
-cask 'pgadmin4'
 cask 'postman'
 cask 'sketch'
 cask 'sketch-toolbox'


### PR DESCRIPTION
Removed postgresql and pgadmin from Brewfile due to new workflow. Spin up independent PostgreSQL databases in Docker containers.