### PR TITLE
Added gnu-sed to Brewfile

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -91,3 +91,7 @@ done
 fpath=($HOME/.functions "${fpath[@]}")
 
 autoload -U $HOME/.functions/*(:t)
+
+# GNU `sed` is installed as `gsed` on MacOSX.
+# To execute the command as `sed` rather than as `gsed`, add a `gnubin` directory to the PATH from `.zshrc`.
+PATH="$(brew --prefix)/opt/gnu-sed/libexec/gnubin:$PATH"

--- a/Brewfile
+++ b/Brewfile
@@ -6,6 +6,7 @@ brew 'certbot'
 brew 'flow'
 brew 'git'
 brew 'git-lfs'
+brew 'gnu-sed'
 brew 'jq'
 brew 'libomp'
 # After installation, create symlinks for the utilities.


### PR DESCRIPTION
The `sed` command is useful for workflows that involve substituting values based on environment variables within a file. For instance, API keys should never be placed under version control, but are required for the build that's generated by a continuous integration pipeline. 

Often, environment variables can be privately defined via repository settings within a continuous integration service. By adding a placeholder like `API_KEY_PLACEHOLDER` within a configuration file such as `*.toml` or `.env` file (`API_KEY=API_KEY_PLACEHOLDER`), it can be replaced with the actual environment variable's value via the `sed` command:

```
$ sed -i s/API_KEY_PLACEHOLDER/$API_KEY/g <configuration-file>
```

In MacOSX, the above `sed` command will yield an "undefined label" error message:

![](https://www.dl.dropboxusercontent.com/s/8b94n8ifh71jgdt/Screen%20Shot%202020-10-08%20at%202.51.19%20PM.png)

The `-i` option requires a parameter that indicates what extension should be added for the backup file (for example, `.bak`). Hence, it would work if done like this:

```
$ sed -i .bak s/API_KEY_PLACEHOLDER/$API_KEY/g <configuration-file>
```

To uniformly test this command on both MacOSX and other Unix-based systems, install `gnu-sed` via Homebrew.